### PR TITLE
AudioStreamingLibCore: fix file copy on Windows

### DIFF
--- a/AudioStreamingLibCore/AudioStreamingLibCore/AudioStreamingLibCore.pri
+++ b/AudioStreamingLibCore/AudioStreamingLibCore/AudioStreamingLibCore.pri
@@ -80,9 +80,9 @@ SOURCES += $$MACOS_R8BRAIN_RESAMPLER_INCLUDE/r8bbase.cpp
 
 #Copy header files
 
-copyfile1.commands = $(COPY_FILE) $$PWD/AudioStreamingLibCore $$PWD/../include
-copyfile2.commands = $(COPY_FILE) $$PWD/audiostreaminglibcore.h $$PWD/../include
-copyfile3.commands = $(COPY_FILE) $$PWD/discoverclient.h $$PWD/../include
+copyfile1.commands = $(COPY_FILE) $$shell_path($$PWD/AudioStreamingLibCore) $$shell_path($$PWD/../include)
+copyfile2.commands = $(COPY_FILE) $$shell_path($$PWD/audiostreaminglibcore.h) $$shell_path($$PWD/../include)
+copyfile3.commands = $(COPY_FILE) $$shell_path($$PWD/discoverclient.h) $$shell_path($$PWD/../include)
 
 first.depends = $(first) copyfile1 copyfile2 copyfile3
 


### PR DESCRIPTION
`shell_path()` converts the slashes to backslashes, if QMake is running on Windows.

The issue appeared in 67d6548afab70d35607374d4776a127f8a50d0fc.